### PR TITLE
Fix title

### DIFF
--- a/teletext.py
+++ b/teletext.py
@@ -105,7 +105,7 @@ def download_tafel(conn, tafel, rubrik):
     
     soup = BeautifulSoup(r.data, 'html.parser')
     desc = soup.find('div', class_='std')
-    title = soup.find('h1')
+    title = soup.find('h2')
     if desc is not None and title is not None:
         title = title.text.replace("<h1>","")
         title = title.replace("<b>","")


### PR DESCRIPTION
Apparently tagesschau.de changed their layout of the mobile website to include the category now as `<h1>`. The article title is now inside a `<h2>`. So currently my feed looks like this:
```
Nachrichten: tagesschau: Nachrichten
Aus aller Welt: Aus aller Welt: Nachrichten
```

With this patch, titles are parsed correctly again:
```
Londons Bürgermeister übt Kritik                                    
Flüge aus Großbritannien verboten
RKI: 22.771 Neuinfektionen
```